### PR TITLE
feat: enforce per-user host access control

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,10 @@ function isRecordOfUser(data: unknown): data is Record<string, User> {
 }
 
 function normalizeHost(host: string): string {
-    return host.split(':')[0]?.toLowerCase() ?? '';
+    const primaryHost = host.split(',')[0] ?? '';
+    const withoutPort = primaryHost.split(':')[0] ?? '';
+    const trimmed = withoutPort.trim().replace(/\.$/, '');
+    return trimmed.toLowerCase();
 }
 
 function isHostAllowed(host: string, allowedHosts?: string[]): boolean {
@@ -140,7 +143,7 @@ function isHostAllowed(host: string, allowedHosts?: string[]): boolean {
     const normalizedHost = normalizeHost(host);
 
     return allowedHosts.some((allowedHost) => {
-        const normalizedAllowed = normalizeHost(allowedHost.trim());
+        const normalizedAllowed = normalizeHost(allowedHost);
         if (!normalizedAllowed) return false;
 
         if (normalizedAllowed.startsWith('*.')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,8 +129,12 @@ function normalizeHost(host: string): string {
 }
 
 function isHostAllowed(host: string, allowedHosts?: string[]): boolean {
-    if (!allowedHosts || allowedHosts.length === 0) {
+    if (!allowedHosts) {
         return true;
+    }
+
+    if (allowedHosts.length === 0) {
+        return false;
     }
 
     const normalizedHost = normalizeHost(host);


### PR DESCRIPTION
## Summary
- allow user records to declare optional allowedHosts lists
- validate loaded user configuration for the new structure and normalize host comparisons
- enforce per-user host access checks in the verify handler with wildcard support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690b2c86ea18832aa225bd8ec34e3e56